### PR TITLE
Adding read string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,4 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-/config/plc_admin.yaml
+ros2_pyads/config/*
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -158,5 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-ros2_pyads/config/*
+/ros2_pyads/config/plc_admin.yaml
 .vscode/*

--- a/ros2_pyads/ros2_pyads/ads_com_node.py
+++ b/ros2_pyads/ros2_pyads/ads_com_node.py
@@ -4,7 +4,7 @@ import yaml
 import rclpy
 from rclpy.node import Node
 from ros2_pyads.ads_com import ADSCom
-from ros2_pyads_interfaces.srv import ReadBool, WriteBool
+from ros2_pyads_interfaces.srv import ReadBool, WriteBool, ReadString
 
 
 class ADSComNode(Node):
@@ -42,6 +42,24 @@ class ADSComNode(Node):
         # Create Service Servers
         self.srv_read_bool = self.create_service(ReadBool, self.get_name() + '/read_bool', self.read_bool_callback)
         self.srv_write_bool = self.create_service(WriteBool, self.get_name() + '/write_bool', self.write_bool_callback)
+        self.srv_read_string = self.create_service(ReadString, self.get_name() + '/read_string', self.read_string_callback)
+
+    def read_string_callback(self, request, response):
+        """
+        Reads a string variable from the PLC.
+
+        :param request: The request object containing the tag name to read.
+        :param response: The response object containing the read value.
+        """
+        try:
+            response.tag_value = bytearray(self.ads_com.read_by_name(request.tag_name, pyads.PLCTYPE_BYTE * (request.size + 1))).decode().strip("\00")
+            response.success = True
+            response.msg = "Successfully read string."
+        except Exception as e:
+            self.get_logger().error(f"Failed to read string: {e}")
+            response.success = False
+            response.msg = str(e)
+        return response
 
     def read_bool_callback(self, request, response):
         """

--- a/ros2_pyads_interfaces/CMakeLists.txt
+++ b/ros2_pyads_interfaces/CMakeLists.txt
@@ -20,6 +20,7 @@ set(msg_files
 set(srv_files
         "srv/ReadBool.srv"
         "srv/WriteBool.srv"
+        "srv/ReadString.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/ros2_pyads_interfaces/srv/ReadString.srv
+++ b/ros2_pyads_interfaces/srv/ReadString.srv
@@ -1,0 +1,6 @@
+string tag_name
+int size
+---
+string tag_value
+bool success
+string msg


### PR DESCRIPTION
In this pull request, I have moved the .gitignore to the top level and added .vscode/* configuration files to it. I have also added the ReadString service to the package. This service takes the tag_name and size as inputs. This solutions allows clients to request strings larger than the pyads 1024 character limit. 